### PR TITLE
bugfix/missing-tb-object

### DIFF
--- a/src/Threebox.js
+++ b/src/Threebox.js
@@ -657,7 +657,7 @@ Threebox.prototype = {
 			while (this.world.children.length > 0) {
 				let obj = this.world.children[0];
 				if (dispose) obj.dispose();
-				tb.remove(obj);
+				map.tb.remove(obj);
 			};
 			clear('clear finished');
 		});


### PR DESCRIPTION
used tb reference stored within the map object to use the threebox remove function